### PR TITLE
fix: restore orchestrator factory for debug sync

### DIFF
--- a/app/services/orchestrator.py
+++ b/app/services/orchestrator.py
@@ -45,3 +45,25 @@ class SyncOrchestrator:
 
     def list_messages(self, course_id: int):
         return self.messages.list_all(course_id)
+
+    async def run(self, session, course_id: int) -> Dict:
+        """Backward compatible wrapper around :func:`sync_all`.
+
+        The web application historically expected a ``run`` coroutine on the
+        orchestrator instance.  The implementation was later renamed to
+        ``sync_all`` but the debug endpoint still imports and calls ``run``.
+        Providing this thin wrapper preserves the previous API and simply
+        forwards the call to :func:`sync_all`.
+        """
+        return await self.sync_all(session, course_id)
+
+
+def create_orchestrator() -> SyncOrchestrator:
+    """Factory used by the web layer to lazily construct a synchronizer.
+
+    The factory mirrors the global ``SYNC`` instance in ``app.webapp`` and is
+    needed by the debug endpoint which imports ``create_orchestrator``.
+    """
+    from app.config import CONFIG
+
+    return SyncOrchestrator(Path(CONFIG.data_root))


### PR DESCRIPTION
## Summary
- add missing `create_orchestrator` factory and `run` wrapper on `SyncOrchestrator`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aadc26e5e48324b0e8a691deb468de