### PR TITLE
Add foundational test coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_browser_async.py
+++ b/tests/test_browser_async.py
@@ -1,0 +1,18 @@
+import base64
+import pytest
+
+pytest.importorskip("playwright.async_api")
+from automation.browser_async import AsyncKidumSession
+
+
+def test_jwt_helpers():
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b'=').decode()
+    payload = base64.urlsafe_b64encode(b'{"sub":"123"}').rstrip(b'=').decode()
+    sig = base64.urlsafe_b64encode(b'sig').rstrip(b'=').decode()
+    token = f"{header}.{payload}.{sig}"
+
+    assert AsyncKidumSession._looks_like_jwt(token)
+    session = AsyncKidumSession()
+    assert session._decode_jwt_sub(token) == "123"
+
+    assert not AsyncKidumSession._looks_like_jwt("not a token")

--- a/tests/test_course_store.py
+++ b/tests/test_course_store.py
@@ -1,0 +1,8 @@
+from app.db.storage import CourseStore
+
+
+def test_course_store_paths(tmp_path):
+    store = CourseStore(tmp_path, 5, "teacher")
+    expected_base = tmp_path / "courses" / "teacher" / "5"
+    assert store.base == expected_base
+    assert store.db_path("foo.db") == expected_base / "foo.db"

--- a/tests/test_distance_syncer.py
+++ b/tests/test_distance_syncer.py
@@ -1,0 +1,36 @@
+import asyncio
+from app.services.distance_syncer import DistanceSyncer
+
+class DummySession:
+    def __init__(self, data):
+        self.data = data
+
+    async def api_get_distance_details(self, course_id):
+        return self.data
+
+
+def test_sync_and_collect(tmp_path):
+    session = DummySession([
+        {"student_id": "s1", "student_name": "Alice", "gap": 3},
+        {"student_id": "s2", "student_name": "Bob", "gap": 2},
+    ])
+    syncer = DistanceSyncer(tmp_path)
+
+    result1 = asyncio.run(syncer.sync_and_collect(session, 1))
+    assert result1["inserted"] == 2
+    assert result1["updated"] == 0
+    assert len(result1["changes"]) == 2
+
+    # Update one record
+    session.data = [
+        {"student_id": "s1", "student_name": "Alice", "gap": 5},
+        {"student_id": "s2", "student_name": "Bob", "gap": 2},
+    ]
+    result2 = asyncio.run(syncer.sync_and_collect(session, 1))
+    assert result2["inserted"] == 0
+    assert result2["updated"] == 1
+    change = result2["changes"][0]
+    assert change[0] == "updated"
+    assert change[1] == "Alice"
+    assert change[2] == 3
+    assert change[3] == 5

--- a/tests/test_messages_store.py
+++ b/tests/test_messages_store.py
@@ -1,0 +1,26 @@
+from app.services.messages_store import MessagesStore
+
+
+def test_messages_store_upsert_and_list(tmp_path):
+    store = MessagesStore(tmp_path)
+    course_id = 7
+
+    # insert message
+    store.upsert_message(course_id, "distance", "s1", "Alice", "msg1", created_at=100)
+    rows = store.list_all(course_id)
+    assert rows == [
+        {
+            "db_type": "distance",
+            "student_id": "s1",
+            "student_name": "Alice",
+            "created_at": 100,
+            "message": "msg1",
+        }
+    ]
+
+    # update same message
+    store.upsert_message(course_id, "distance", "s1", "Alice", "msg2", created_at=200)
+    rows2 = store.list_all(course_id)
+    assert len(rows2) == 1
+    assert rows2[0]["message"] == "msg2"
+    assert rows2[0]["created_at"] == 200

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,28 @@
+import asyncio
+from app.services.orchestrator import SyncOrchestrator
+
+class DummySession:
+    def __init__(self, data):
+        self.data = data
+
+    async def api_get_distance_details(self, course_id):
+        return self.data
+
+
+def test_sync_all(tmp_path, monkeypatch):
+    monkeypatch.setattr('app.services.orchestrator.time.time', lambda: 111)
+
+    session = DummySession([
+        {"student_id": "s1", "student_name": "Alice", "gap": 3},
+        {"student_id": "s2", "student_name": "Bob", "gap": 1},
+    ])
+
+    orchestrator = SyncOrchestrator(tmp_path)
+    result = asyncio.run(orchestrator.sync_all(session, 1))
+
+    assert result["distance"]["inserted"] == 2
+    assert result["messages_emitted"] == 2
+
+    messages = orchestrator.list_messages(1)
+    assert len(messages) == 2
+    assert all(m["created_at"] == 111 for m in messages)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+from app.services import paths
+from app.config import CONFIG
+
+
+def test_paths_functions(tmp_path, monkeypatch):
+    # Redirect data root to temporary directory
+    monkeypatch.setattr(CONFIG, "data_root", str(tmp_path))
+
+    # data_root
+    assert paths.data_root() == Path(tmp_path)
+
+    # course_dir creates directory
+    cdir = paths.course_dir(123)
+    assert cdir == Path(tmp_path) / "courses" / "123"
+    assert cdir.exists()
+
+    # distance_db_path and messages_db_path
+    distance_path = paths.distance_db_path(123)
+    messages_path = paths.messages_db_path(123)
+    assert distance_path == cdir / "distance.db"
+    assert messages_path == cdir / "messages.db"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,4 @@
+def test_import_main():
+    """Basic import smoke test for application entry point."""
+    import importlib
+    assert importlib.import_module("app.main")


### PR DESCRIPTION
## Summary
- add sys.path setup for tests
- cover path helpers and storage utilities
- test data sync and message orchestration
- verify JWT helper logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aae72f3c388324ace502b1e026e0d4