### PR TITLE
Implement student message template rendering

### DIFF
--- a/app/services/orchestrator.py
+++ b/app/services/orchestrator.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 from .distance_syncer import DistanceSyncer
 from .messages_store import MessagesStore
+from logic.messages import build_student_message
 import time
 
 class SyncOrchestrator:
@@ -22,13 +23,14 @@ class SyncOrchestrator:
         # Emit/update messages
         now = int(time.time())
         for (kind, sname, old_gap, new_gap, sid) in dist["changes"]:
-            if kind == "inserted":
-                text = f"נוצר רישום פער מטרה ראשוני עבור {sname}: {new_gap}."
-            else:
-                if old_gap is None:
-                    text = f"עדכון פער מטרה עבור {sname}: {new_gap}."
-                else:
-                    text = f"עדכון פער מטרה עבור {sname}: {old_gap} → {new_gap}."
+            text = build_student_message(
+                {
+                    "kind": kind,
+                    "student_name": sname,
+                    "old_gap": old_gap,
+                    "new_gap": new_gap,
+                }
+            )
             self.messages.upsert_message(
                 course_id=course_id,
                 db_type="distance",

--- a/logic/messages.py
+++ b/logic/messages.py
@@ -1,7 +1,54 @@
+"""Utilities for rendering student-facing messages.
+
+The project stores message templates under :mod:`logic.templates` and renders
+them using `Jinja2 <https://jinja.palletsprojects.com/>`_.  Historically the
+function responsible for rendering a student notification was left as a
+``TODO`` which caused callers to fail at runtime.
+
+This module now exposes :func:`build_student_message` which loads the
+``student_message.j2`` template and renders it with the provided context.
+The template covers both ``inserted`` and ``updated`` distance records and
+expects the following context keys:
+
+``kind``
+    ``"inserted"`` or ``"updated"`` – the type of change.
+
+``student_name``
+    The student's display name.
+
+``old_gap`` / ``new_gap``
+    Previous and current gap values.  ``old_gap`` may be ``None`` when an
+    initial gap record is created.
+"""
+
 from __future__ import annotations
 
-def build_student_message(ctx: dict) -> str:
+from pathlib import Path
+from typing import Dict
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+_TEMPLATE_ENV = Environment(
+    loader=FileSystemLoader(Path(__file__).with_name("templates")),
+    autoescape=select_autoescape([]),
+)
+
+
+def build_student_message(ctx: Dict) -> str:
+    """Render a message for a student using the Jinja2 template.
+
+    Parameters
+    ----------
+    ctx:
+        Rendering context containing the fields described in the module
+        documentation.
+
+    Returns
+    -------
+    str
+        The rendered message text.
     """
-    TODO (you define): template fields and rendering rules.
-    """
-    raise NotImplementedError("Message rendering not defined yet.")
+
+    template = _TEMPLATE_ENV.get_template("student_message.j2")
+    return template.render(**ctx)
+

--- a/logic/templates/student_message.j2
+++ b/logic/templates/student_message.j2
@@ -1,0 +1,8 @@
+{%- if kind == 'inserted' -%}
+נוצר רישום פער מטרה ראשוני עבור {{ student_name }}: {{ new_gap }}.
+{%- elif old_gap is none -%}
+עדכון פער מטרה עבור {{ student_name }}: {{ new_gap }}.
+{%- else -%}
+עדכון פער מטרה עבור {{ student_name }}: {{ old_gap }} → {{ new_gap }}.
+{%- endif -%}
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    asyncio: mark a test as using asyncio
+


### PR DESCRIPTION
## Summary
- Implement Jinja2-based `build_student_message` to render student notifications from template
- Use `build_student_message` in `SyncOrchestrator` to create messages
- Add `pytest.ini` registering `asyncio` marker to silence warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaeafe806c8324974cfdef58317427