### PR TITLE
Load .env before config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from typing import List
+from dotenv import load_dotenv
+
+# Ensure variables from a local .env file are available before constructing the config
+load_dotenv()
 
 @dataclass
 class _Config:


### PR DESCRIPTION
## Summary
- load environment variables from .env before constructing CONFIG

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaeef39d948324bb59e8b9a0dda5b9