### PR TITLE
feat: isolate databases per environment

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -25,5 +25,6 @@ class _Config:
         ).split(",")
     )
     data_root: str = os.getenv("DATA_ROOT", "data")
+    env: str = os.getenv("APP_ENV", "dev")
 
 CONFIG = _Config()

--- a/app/services/distance_syncer.py
+++ b/app/services/distance_syncer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
+from app.config import CONFIG
 
 class DistanceSyncer:
     """
@@ -13,7 +14,8 @@ class DistanceSyncer:
     def _db_path(self, course_id: int) -> Path:
         p = self.root / "courses" / str(course_id)
         p.mkdir(parents=True, exist_ok=True)
-        return p / "distance.db"
+        fname = f"distance_{CONFIG.env}.db" if CONFIG.env else "distance.db"
+        return p / fname
 
     def _conn(self, course_id: int):
         path = self._db_path(course_id)

--- a/app/services/messages_store.py
+++ b/app/services/messages_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import sqlite3, time
 from pathlib import Path
 from typing import List, Dict, Optional
+from app.config import CONFIG
 
 class MessagesStore:
     def __init__(self, data_root: Path):
@@ -10,7 +11,8 @@ class MessagesStore:
     def _db_path(self, course_id: int) -> Path:
         p = self.root / "courses" / str(course_id)
         p.mkdir(parents=True, exist_ok=True)
-        return p / "messages.db"
+        fname = f"messages_{CONFIG.env}.db" if CONFIG.env else "messages.db"
+        return p / fname
 
     def _conn(self, course_id: int):
         path = self._db_path(course_id)

--- a/app/services/paths.py
+++ b/app/services/paths.py
@@ -12,7 +12,9 @@ def course_dir(course_id: int) -> Path:
     return p
 
 def distance_db_path(course_id: int) -> Path:
-    return course_dir(course_id) / "distance.db"
+    fname = f"distance_{CONFIG.env}.db" if CONFIG.env else "distance.db"
+    return course_dir(course_id) / fname
 
 def messages_db_path(course_id: int) -> Path:
-    return course_dir(course_id) / "messages.db"
+    fname = f"messages_{CONFIG.env}.db" if CONFIG.env else "messages.db"
+    return course_dir(course_id) / fname

--- a/tests/test_live_db_comparison.py
+++ b/tests/test_live_db_comparison.py
@@ -6,6 +6,7 @@ pytest.importorskip("playwright.async_api")
 
 from automation.browser_async import AsyncKidumSession
 from app.services.distance_syncer import DistanceSyncer
+from app.config import CONFIG
 
 
 @pytest.mark.asyncio
@@ -31,11 +32,12 @@ async def test_distance_db_matches_remote(tmp_path):
             pytest.skip("course id missing in API data")
         course_id = int(course_id)
 
+        CONFIG.env = "test"
         syncer = DistanceSyncer(tmp_path)
         await syncer.sync_and_collect(session, course_id)
         remote_rows = await session.api_get_distance_details(course_id)
 
-        db_path = tmp_path / "courses" / str(course_id) / "distance.db"
+        db_path = tmp_path / "courses" / str(course_id) / f"distance_{CONFIG.env}.db"
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         rows = conn.execute("SELECT * FROM distance").fetchall()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -6,6 +6,7 @@ from app.config import CONFIG
 def test_paths_functions(tmp_path, monkeypatch):
     # Redirect data root to temporary directory
     monkeypatch.setattr(CONFIG, "data_root", str(tmp_path))
+    monkeypatch.setattr(CONFIG, "env", "test")
 
     # data_root
     assert paths.data_root() == Path(tmp_path)
@@ -18,5 +19,5 @@ def test_paths_functions(tmp_path, monkeypatch):
     # distance_db_path and messages_db_path
     distance_path = paths.distance_db_path(123)
     messages_path = paths.messages_db_path(123)
-    assert distance_path == cdir / "distance.db"
-    assert messages_path == cdir / "messages.db"
+    assert distance_path == cdir / "distance_test.db"
+    assert messages_path == cdir / "messages_test.db"


### PR DESCRIPTION
## Summary
- add `APP_ENV` config value to track current environment
- append environment name to distance and messages DB filenames
- update tests for environment-scoped database paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaf19cc2f483249a36e5321ee8f56a