### PR TITLE
Derive env name from base URL

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from typing import List
+from urllib.parse import urlparse
 from dotenv import load_dotenv
 
 # Ensure variables from a local .env file are available before constructing the config
@@ -25,6 +26,18 @@ class _Config:
         ).split(",")
     )
     data_root: str = os.getenv("DATA_ROOT", "data")
-    env: str = os.getenv("APP_ENV", "dev")
+    env: str = os.getenv("APP_ENV", "")
+
+    def __post_init__(self) -> None:
+        """Ensure ``env`` reflects the current base URL.
+
+        If ``APP_ENV`` is not provided, derive a stable environment name from
+        the hostname.  This avoids collisions when running against different
+        deployments and ensures debug routes read the correct database.
+        """
+        if not self.env:
+            host = urlparse(self.base_url).netloc or "dev"
+            # Replace characters that are problematic in filenames
+            self.env = host.replace(":", "_").replace(".", "_")
 
 CONFIG = _Config()


### PR DESCRIPTION
## Summary
- derive environment name from base URL when APP_ENV unset to prevent mixing data between deployments

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaf396be5c8324a5b5e10cb9309a52