### PR TITLE
Implement messages workflow with editable UI

### DIFF
--- a/app/services/messages_store.py
+++ b/app/services/messages_store.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List, Dict, Optional
 from app.config import CONFIG
 
+
 class MessagesStore:
     def __init__(self, data_root: Path):
         self.root = Path(data_root)
@@ -33,11 +34,19 @@ class MessagesStore:
                     message TEXT NOT NULL,
                     UNIQUE(db_type, student_id)
                 )
-                """
+                """,
             )
             conn.commit()
 
-    def upsert_message(self, course_id: int, db_type: str, student_id: str, student_name: str, message: str, created_at: Optional[int] = None):
+    def upsert_message(
+        self,
+        course_id: int,
+        db_type: str,
+        student_id: str,
+        student_name: str,
+        message: str,
+        created_at: Optional[int] = None,
+    ):
         self.ensure_schema(course_id)
         ts = int(time.time()) if created_at is None else created_at
         with self._conn(course_id) as conn:
@@ -54,19 +63,69 @@ class MessagesStore:
             )
             conn.commit()
 
-    def list_all(self, course_id: int) -> List[Dict]:
+    def list_all(self, course_id: int, msg_type: Optional[str] = None) -> List[Dict]:
+        """Return messages for a course, optionally filtered by type."""
+
+        self.ensure_schema(course_id)
+        query = (
+            "SELECT id, db_type, student_id, student_name, created_at, message "
+            "FROM messages"
+        )
+        params: List[object] = []
+        if msg_type and msg_type != "all":
+            query += " WHERE db_type=?"
+            params.append(msg_type)
+        query += " ORDER BY created_at DESC"
+
+        with self._conn(course_id) as conn:
+            rows = conn.execute(query, params).fetchall()
+
+        out: List[Dict] = []
+        for (mid, db_type, sid, sname, created_at, msg) in rows:
+            out.append(
+                {
+                    "id": mid,
+                    "db_type": db_type,
+                    "student_id": sid,
+                    "student_name": sname,
+                    "created_at": created_at,
+                    "message": msg,
+                }
+            )
+        return out
+
+    def list_types(self, course_id: int) -> List[str]:
+        """Return distinct message types for the course."""
+
         self.ensure_schema(course_id)
         with self._conn(course_id) as conn:
             rows = conn.execute(
-                "SELECT db_type, student_id, student_name, created_at, message FROM messages ORDER BY created_at DESC"
+                "SELECT DISTINCT db_type FROM messages ORDER BY db_type"
             ).fetchall()
-        out = []
-        for (db_type, sid, sname, created_at, msg) in rows:
-            out.append({
-                "db_type": db_type,
-                "student_id": sid,
-                "student_name": sname,
-                "created_at": created_at,
-                "message": msg,
-            })
-        return out
+        return [r[0] for r in rows]
+
+    def update_message(self, course_id: int, msg_id: int, message: str) -> Dict:
+        """Update only the ``message`` field for a row and return the updated row."""
+
+        self.ensure_schema(course_id)
+        with self._conn(course_id) as conn:
+            cur = conn.execute(
+                "UPDATE messages SET message=? WHERE id=?",
+                (message, msg_id),
+            )
+            if cur.rowcount == 0:
+                raise KeyError(msg_id)
+            conn.commit()
+            row = conn.execute(
+                "SELECT id, db_type, student_id, student_name, created_at, message FROM messages WHERE id=?",
+                (msg_id,),
+            ).fetchone()
+
+        return {
+            "id": row[0],
+            "db_type": row[1],
+            "student_id": row[2],
+            "student_name": row[3],
+            "created_at": row[4],
+            "message": row[5],
+        }

--- a/app/services/orchestrator.py
+++ b/app/services/orchestrator.py
@@ -46,8 +46,14 @@ class SyncOrchestrator:
             "messages_emitted": len(dist["changes"]),
         }
 
-    def list_messages(self, course_id: int):
-        return self.messages.list_all(course_id)
+    def list_messages(self, course_id: int, msg_type: str | None = None):
+        return self.messages.list_all(course_id, msg_type)
+
+    def list_message_types(self, course_id: int):
+        return self.messages.list_types(course_id)
+
+    def update_message(self, course_id: int, msg_id: int, message: str):
+        return self.messages.update_message(course_id, msg_id, message)
 
     async def run(self, session, course_id: int) -> Dict:
         """Backward compatible wrapper around :func:`sync_all`.

--- a/app/webapp.py
+++ b/app/webapp.py
@@ -54,6 +54,10 @@ class LoginBody(BaseModel):
     username: str
     password: str
 
+
+class PatchMessageBody(BaseModel):
+    message: str
+
 @app.on_event("shutdown")
 async def _shutdown():
     s = _get_session(False)
@@ -175,6 +179,34 @@ async def select_course(body: SelectCourseBody):
     summary = await SYNC.sync_all(s, body.course_id)
 
     return {"ok": True, "selected_id": s.get_selected_course_id(), "summary": summary}
+
+
+@app.get("/messages")
+async def get_messages(course_id: int, type: str = "all"):
+    await _ensure_logged_in()
+    rows = SYNC.list_messages(course_id, None if type == "all" else type)
+    types_present = sorted({r["db_type"] for r in rows})
+    return {"ok": True, "data": rows, "count": len(rows), "types_present": types_present}
+
+
+@app.get("/message_types")
+async def get_message_types(course_id: int):
+    await _ensure_logged_in()
+    types = SYNC.list_message_types(course_id)
+    return {"ok": True, "types": types}
+
+
+@app.patch("/messages/{msg_id}")
+async def patch_message(msg_id: int, body: PatchMessageBody):
+    s = await _ensure_logged_in()
+    if not hasattr(s, "get_selected_course_id") or not s.get_selected_course_id():
+        raise HTTPException(status_code=400, detail="No course selected")
+    course_id = s.get_selected_course_id()
+    try:
+        row = SYNC.update_message(course_id, msg_id, body.message)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return {"ok": True, "data": row}
 
 
 @app.get("/debug/distance", response_class=HTMLResponse)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -81,6 +81,12 @@
       const [loginMsg, setLoginMsg] = useState('');
       const [statusText, setStatusText] = useState('לא מחובר');
       const [courseMsg, setCourseMsg] = useState('');
+      const [messageTypes, setMessageTypes] = useState([]);
+      const [filterType, setFilterType] = useState('all');
+      const [messages, setMessages] = useState([]);
+      const [messagesMsg, setMessagesMsg] = useState('');
+      const [editingId, setEditingId] = useState(null);
+      const [editingText, setEditingText] = useState('');
 
       useEffect(() => {
         refreshStatusAndMaybeLoad();
@@ -107,11 +113,71 @@
             setCourses(res.data || []);
             setSelectedId(res.selected_id ?? '');
             setCourseMsg(`נמצאו ${res.data?.length ?? 0} קורסים.`);
+            if (res.selected_id) {
+              await loadMessageTypes(res.selected_id);
+              await loadMessages(res.selected_id, filterType);
+            }
           } else {
             setCourseMsg('שגיאה בטעינת קורסים.');
           }
         } catch (e) {
           setCourseMsg('שגיאה: ' + (e.message || e));
+        }
+      }
+
+      async function loadMessageTypes(cid) {
+        try {
+          const res = await $get(`/message_types?course_id=${cid}`);
+          if (res && res.ok) setMessageTypes(res.types || []);
+        } catch (e) {
+          /* ignore */
+        }
+      }
+
+      async function loadMessages(cid, type) {
+        setMessagesMsg('טוען הודעות...');
+        try {
+          const res = await $get(`/messages?course_id=${cid}&type=${type}`);
+          if (res && res.ok) {
+            setMessages(res.data || []);
+            setMessagesMsg('');
+            if (res.types_present) setMessageTypes(res.types_present);
+          } else {
+            setMessagesMsg('שגיאה בטעינת הודעות');
+          }
+        } catch (e) {
+          setMessagesMsg('שגיאה: ' + (e.message || e));
+        }
+      }
+
+      function handleTypeChange(e) {
+        const t = e.target.value;
+        setFilterType(t);
+        if (selectedId) loadMessages(selectedId, t);
+      }
+
+      function startEdit(id, text) {
+        setEditingId(id);
+        setEditingText(text);
+      }
+
+      function cancelEdit() {
+        setEditingId(null);
+        setEditingText('');
+      }
+
+      async function saveEdit(id) {
+        try {
+          await fetch(`/messages/${id}`, {
+            method: 'PATCH',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: editingText })
+          });
+          setMessages(m => m.map(row => row.id === id ? { ...row, message: editingText } : row));
+          cancelEdit();
+        } catch (e) {
+          alert('שגיאה: ' + (e.message || e));
         }
       }
 
@@ -156,6 +222,8 @@
         try {
           await $post('/select_course', { course_id: cid });
           setCourseMsg('נשמר ✔');
+          await loadMessageTypes(cid);
+          await loadMessages(cid, filterType);
         } catch (e) {
           setCourseMsg('שגיאה: ' + (e.message || e));
         }
@@ -219,6 +287,71 @@
                       • הבחירה נשמרת בצד השרת עד לבחירה חדשה.
                     </div>
                   </div>
+                </div>
+              </div>
+            )}
+
+            {loggedIn && selectedId && (
+              <div className="mt16">
+                <h3>הודעות</h3>
+                <div className="row">
+                  <div>
+                    <label>סוג הודעות</label>
+                    <select value={filterType} onChange={handleTypeChange}>
+                      <option value="all">הכל</option>
+                      <option value="distance">מרחק מציון היעד</option>
+                      {messageTypes.filter(t => t !== 'distance').map(t => (
+                        <option key={t} value={t}>{t}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label>&nbsp;</label>
+                    <div className="mt8" style={{display:'flex', gap:'8px', alignItems:'center', flexWrap:'wrap'}}>
+                      <button onClick={() => loadMessages(selectedId, filterType)} className="btn secondary">רענן הודעות</button>
+                      <small className="muted">{messagesMsg}</small>
+                    </div>
+                  </div>
+                </div>
+                <div className="mt16" style={{overflowX:'auto'}}>
+                  <table style={{width:'100%', borderCollapse:'collapse'}}>
+                    <thead>
+                      <tr>
+                        <th style={{textAlign:'right'}}>סוג</th>
+                        <th style={{textAlign:'right'}}>שם תלמיד</th>
+                        <th style={{textAlign:'right'}}>נוצר</th>
+                        <th style={{textAlign:'right'}}>הודעה</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {messages.map(m => (
+                        <tr key={m.id}>
+                          <td>{m.db_type}</td>
+                          <td>{m.student_name}</td>
+                          <td>{new Date(m.created_at * 1000).toLocaleString('he-IL')}</td>
+                          <td>
+                            {editingId === m.id ? (
+                              <div style={{display:'flex', gap:'8px', alignItems:'center'}}>
+                                <input value={editingText} onChange={e => setEditingText(e.target.value)} />
+                                <button onClick={() => saveEdit(m.id)} className="btn secondary">שמור</button>
+                                <button onClick={cancelEdit} className="btn ghost">ביטול</button>
+                              </div>
+                            ) : (
+                              <div style={{display:'flex', gap:'8px', alignItems:'center'}}>
+                                <span>{m.message}</span>
+                                <button onClick={() => startEdit(m.id, m.message)} className="btn ghost">ערוך</button>
+                              </div>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                      {!messages.length && (
+                        <tr>
+                          <td colSpan="4" style={{textAlign:'center'}} className="muted">אין הודעות עבור הקורס הזה</td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
                 </div>
               </div>
             )}

--- a/tests/test_messages_store.py
+++ b/tests/test_messages_store.py
@@ -10,6 +10,7 @@ def test_messages_store_upsert_and_list(tmp_path):
     rows = store.list_all(course_id)
     assert rows == [
         {
+            "id": rows[0]["id"],  # auto-generated
             "db_type": "distance",
             "student_id": "s1",
             "student_name": "Alice",
@@ -18,9 +19,18 @@ def test_messages_store_upsert_and_list(tmp_path):
         }
     ]
 
-    # update same message
-    store.upsert_message(course_id, "distance", "s1", "Alice", "msg2", created_at=200)
+    # update same message via helper
+    updated = store.update_message(course_id, rows[0]["id"], "msg2")
+    assert updated["message"] == "msg2"
     rows2 = store.list_all(course_id)
     assert len(rows2) == 1
     assert rows2[0]["message"] == "msg2"
-    assert rows2[0]["created_at"] == 200
+    # created_at should remain unchanged
+    assert rows2[0]["created_at"] == 100
+
+    # add another type and ensure filtering/types work
+    store.upsert_message(course_id, "other", "s2", "Bob", "m2", created_at=150)
+    types = store.list_types(course_id)
+    assert set(types) == {"distance", "other"}
+    distance_only = store.list_all(course_id, msg_type="distance")
+    assert len(distance_only) == 1


### PR DESCRIPTION
## Summary
- add SQLite-backed message queries with filtering, type listing, and update support
- expose `/messages`, `/message_types`, and patch endpoints in FastAPI
- expand React frontend to show messages table with filter and inline editing

## Testing
- `pytest tests/test_messages_store.py -q`
- `pytest -q` *(fails: BrowserType.launch executable missing; run `playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2a61587c8324b1e033664b3c8ca9