### PR TITLE
Add regression test for failed login cleanup

### DIFF
--- a/app/webapp.py
+++ b/app/webapp.py
@@ -105,7 +105,8 @@ async def login(body: LoginBody):
     frontend to redirect straight to the messages page.
 
     To avoid this, ensure we clean up the session on failure and reset the
-    global reference before returning an error.
+    global reference before returning an error.  A regression test exercises
+    this path to prevent future regressions.
     """
 
     global _session

--- a/tests/test_login_failure.py
+++ b/tests/test_login_failure.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+import app.webapp as webapp
+
+
+class DummySession:
+    def __init__(self, ok=False):
+        self.ok = ok
+        self.closed = False
+
+    async def login(self, username: str, password: str) -> bool:
+        return self.ok
+
+    async def close(self):
+        self.closed = True
+
+    def get_logged_in_display_name(self):
+        return "dummy"
+
+    def get_teacher_id(self):
+        return 0
+
+
+def test_failed_login_clears_session(monkeypatch):
+    dummy = DummySession(ok=False)
+    # Patch AsyncKidumSession to return our dummy session
+    monkeypatch.setattr(webapp, "AsyncKidumSession", lambda: dummy)
+    client = TestClient(webapp.app)
+
+    # Attempt login with bad credentials
+    res = client.post("/login", json={"username": "bad", "password": "bad"})
+    assert res.status_code == 401
+    assert webapp._session is None
+    assert dummy.closed is True
+
+    # Status endpoint should report logged_in=False
+    status = client.get("/status").json()
+    assert status["logged_in"] is False


### PR DESCRIPTION
## Summary
- document session reset on failed login
- add regression test ensuring failed login clears session and reports logged out

## Testing
- `pytest tests/test_login_failure.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab3b020b148324a4dad6ba5cf6a49c