### PR TITLE
fix missing tiptap dependency to load login page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
         "@tanstack/react-query": "^5.0.0",
         "@tiptap/extension-link": "^2.0.0-beta.220",
         "@tiptap/extension-list-item": "^2.0.0-beta.220",
-        "@tiptap/extension-text-align": "^2.0.0-beta.220",
+        "@tiptap/extension-text-align": "^2.26.1",
         "@tiptap/extension-underline": "^2.0.0-beta.220",
         "@tiptap/react": "^2.0.0-beta.220",
         "@tiptap/starter-kit": "^2.0.0-beta.220",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "@tiptap/extension-underline": "^2.0.0-beta.220",
     "@tiptap/extension-link": "^2.0.0-beta.220",
     "@tiptap/extension-list-item": "^2.0.0-beta.220",
-    "@tiptap/extension-text-align": "^2.0.0-beta.220",
+    "@tiptap/extension-text-align": "^2.26.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.15.0",


### PR DESCRIPTION
## Summary
- install `@tiptap/extension-text-align` so Vite can build the frontend

## Testing
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3f3e64b883249e56d550f16e5168