### PR TITLE
Serve frontend source files to eliminate 404 for main.tsx

### DIFF
--- a/app/webapp.py
+++ b/app/webapp.py
@@ -32,6 +32,11 @@ app.mount(
     StaticFiles(directory=DIST_DIR / "assets", check_dir=False),
     name="assets",
 )
+app.mount(
+    "/src",
+    StaticFiles(directory=BASE_DIR / "frontend" / "src", check_dir=False),
+    name="src",
+)
 
 # CORS
 app.add_middleware(


### PR DESCRIPTION
## Summary
- Mount `/src` directory so FastAPI can serve frontend source files when the built assets aren't present

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab409e0c9083249afb1ba532aab437