### PR TITLE
fix: ensure status reports logged-out sessions

### DIFF
--- a/app/webapp.py
+++ b/app/webapp.py
@@ -204,12 +204,13 @@ async def courses(names_only: bool = False):
 @app.get("/status")
 async def status():
     s = _get_session(False)
+    logged_in = bool(s and s.get_logged_in_display_name())
     return {
         "ok": True,
-        "logged_in": bool(s),
-        "display_name": s.get_logged_in_display_name() if s else None,
-        "teacher_id": s.get_teacher_id() if s else None,
-        "selected_id": s.get_selected_course_id() if (s and hasattr(s, "get_selected_course_id")) else None,
+        "logged_in": logged_in,
+        "display_name": s.get_logged_in_display_name() if logged_in else None,
+        "teacher_id": s.get_teacher_id() if logged_in else None,
+        "selected_id": s.get_selected_course_id() if (logged_in and hasattr(s, "get_selected_course_id")) else None,
     }
 
 # Persist chosen course (ensure these helpers exist on AsyncKidumSession)

--- a/tests/test_status_session.py
+++ b/tests/test_status_session.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+import app.webapp as webapp
+
+class DummySession:
+    def __init__(self):
+        self.closed = False
+    async def close(self):
+        self.closed = True
+    def get_logged_in_display_name(self):
+        return None
+    def get_teacher_id(self):
+        return None
+    def get_selected_course_id(self):
+        return None
+
+
+def test_status_reports_logged_out_for_partial_session():
+    dummy = DummySession()
+    webapp._session = dummy
+    client = TestClient(webapp.app)
+    status = client.get('/status').json()
+    assert status == {
+        'ok': True,
+        'logged_in': False,
+        'display_name': None,
+        'teacher_id': None,
+        'selected_id': None,
+    }
+    client.post('/logout')
+    assert dummy.closed is True
+    assert webapp._session is None


### PR DESCRIPTION
## Summary
- refine `/status` endpoint to verify the session has a display name before reporting `logged_in`
- add regression test for partial sessions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab42d575cc8324a9a8f07cbaab8066