### PR TITLE
Handle legacy message databases without course_id column

### DIFF
--- a/app/services/messages_store.py
+++ b/app/services/messages_store.py
@@ -39,9 +39,18 @@ class MessagesStore:
         return conn
 
     def ensure_schema(self, course_id: int) -> None:
-        """Create the database schema if it does not yet exist."""
+        """Create or upgrade the messages schema for ``course_id``.
+
+        Older versions of the database did not include a ``course_id`` column
+        because each course used its own SQLite file.  The newer schema embeds
+        the course id in every row and uses it in the indices.  This helper
+        therefore needs to both create a fresh schema and upgrade existing
+        databases which still use the legacy layout.
+        """
 
         with self._conn(course_id) as conn:
+            # Create table if it does not exist.  ``course_id`` is part of the
+            # canonical schema but older databases may miss it.
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS messages (
@@ -59,6 +68,21 @@ class MessagesStore:
                 )
                 """,
             )
+
+            # Upgrade legacy databases lacking the ``course_id`` column.
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)")}
+            if "course_id" not in cols:
+                conn.execute(
+                    f"ALTER TABLE messages ADD COLUMN course_id INTEGER NOT NULL DEFAULT {course_id}"
+                )
+                # Ensure existing rows get the proper course id value.
+                conn.execute("UPDATE messages SET course_id=?", (course_id,))
+
+            # Recreate indices with the correct column list.  Dropping first
+            # handles upgrades from older schemas where the indices referenced
+            # only ``db_type`` and ``student_id``.
+            conn.execute("DROP INDEX IF EXISTS idx_messages_unique")
+            conn.execute("DROP INDEX IF EXISTS idx_messages_type")
             conn.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_unique ON messages(course_id, db_type, student_id)"
             )

--- a/tests/test_messages_store.py
+++ b/tests/test_messages_store.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 from app.services.messages_store import MessagesStore
 
 
@@ -51,3 +53,38 @@ def test_messages_store_upsert_and_list(tmp_path):
     assert set(types) == {"distance", "other"}
     distance_only = store.list_all(course_id, msg_type="distance")
     assert distance_only["total"] == 1
+
+
+def test_ensure_schema_upgrades_legacy_db(tmp_path):
+    store = MessagesStore(tmp_path)
+    course_id = 9
+
+    # Manually create a legacy database missing the course_id column.
+    db_path = store._db_path(course_id)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE messages (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            db_type       TEXT    NOT NULL,
+            student_id    TEXT    NOT NULL,
+            student_name  TEXT    NOT NULL,
+            created_at    INTEGER NOT NULL,
+            updated_at    INTEGER NOT NULL,
+            content_html  TEXT    NOT NULL,
+            content_json  TEXT    NOT NULL,
+            source        TEXT    NOT NULL DEFAULT 'auto',
+            meta          TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    # Trigger schema upgrade – should not raise even though the column is absent.
+    assert store.list_types(course_id) == []
+
+    # The migration should have added the course_id column.
+    with sqlite3.connect(db_path) as conn:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)")}
+    assert "course_id" in cols


### PR DESCRIPTION
## Summary
- upgrade MessagesStore.ensure_schema to add missing `course_id` column and rebuild indices
- add regression test covering migration from legacy DB without `course_id`

## Testing
- `pytest tests/test_messages_store.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac222fc634832494f47d85b48ba637