### PR TITLE
fix: add missing updated_at column migration

### DIFF
--- a/app/services/messages_store.py
+++ b/app/services/messages_store.py
@@ -69,7 +69,10 @@ class MessagesStore:
                 """,
             )
 
-            # Upgrade legacy databases lacking the ``course_id`` column.
+            # Upgrade legacy databases lacking columns introduced in newer
+            # versions of the schema.  ``course_id`` was added when the
+            # database moved from one file per course to a shared layout,
+            # while ``updated_at`` was added to support tracking manual edits.
             cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)")}
             if "course_id" not in cols:
                 conn.execute(
@@ -77,6 +80,15 @@ class MessagesStore:
                 )
                 # Ensure existing rows get the proper course id value.
                 conn.execute("UPDATE messages SET course_id=?", (course_id,))
+
+            # Older databases may also miss the ``updated_at`` column.  When
+            # upgrading we add it and backfill its value with ``created_at`` so
+            # existing rows remain consistent with the new schema.
+            if "updated_at" not in cols:
+                conn.execute(
+                    "ALTER TABLE messages ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0"
+                )
+                conn.execute("UPDATE messages SET updated_at=created_at")
 
             # Recreate indices with the correct column list.  Dropping first
             # handles upgrades from older schemas where the indices referenced

--- a/tests/test_messages_store.py
+++ b/tests/test_messages_store.py
@@ -88,3 +88,60 @@ def test_ensure_schema_upgrades_legacy_db(tmp_path):
     with sqlite3.connect(db_path) as conn:
         cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)")}
     assert "course_id" in cols
+
+
+def test_ensure_schema_adds_updated_at(tmp_path):
+    store = MessagesStore(tmp_path)
+    course_id = 11
+
+    # Create legacy database without the ``updated_at`` column.
+    db_path = store._db_path(course_id)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE messages (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            course_id     INTEGER NOT NULL,
+            db_type       TEXT    NOT NULL,
+            student_id    TEXT    NOT NULL,
+            student_name  TEXT    NOT NULL,
+            created_at    INTEGER NOT NULL,
+            content_html  TEXT    NOT NULL,
+            content_json  TEXT    NOT NULL,
+            source        TEXT    NOT NULL DEFAULT 'auto',
+            meta          TEXT
+        )
+        """,
+    )
+    # Insert a sample row so we can verify backfilling.
+    conn.execute(
+        """
+        INSERT INTO messages (
+            course_id, db_type, student_id, student_name,
+            created_at, content_html, content_json, source, meta
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            course_id,
+            "distance",
+            "s1",
+            "Alice",
+            123,
+            "html",
+            "{}",
+            "auto",
+            "{}",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    # Listing messages should trigger the schema upgrade and succeed.
+    rows = store.list_all(course_id)
+    assert rows["total"] == 1
+    assert rows["rows"][0]["updated_at"] == 123
+
+    # ``updated_at`` column should now exist in the schema.
+    with sqlite3.connect(db_path) as conn:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)")}
+    assert "updated_at" in cols


### PR DESCRIPTION
## Summary
- handle legacy message databases missing updated_at column by migrating schema
- test schema upgrade for outdated databases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac23b0be94832498659fb8b66014e5