### PR TITLE
Add migration for missing content_html column in messages database

### DIFF
--- a/app/services/messages_store.py
+++ b/app/services/messages_store.py
@@ -81,6 +81,14 @@ class MessagesStore:
                 # Ensure existing rows get the proper course id value.
                 conn.execute("UPDATE messages SET course_id=?", (course_id,))
 
+            # Legacy databases may also lack ``content_html`` which is used by
+            # the API responses and therefore must exist to avoid query
+            # failures.  Add the column with a sensible default when missing.
+            if "content_html" not in cols:
+                conn.execute(
+                    "ALTER TABLE messages ADD COLUMN content_html TEXT NOT NULL DEFAULT ''"
+                )
+
             # Older databases may also miss the ``updated_at`` column.  When
             # upgrading we add it and backfill its value with ``created_at`` so
             # existing rows remain consistent with the new schema.
@@ -189,13 +197,27 @@ class MessagesStore:
             params.append(f"%{search}%")
         where = " AND ".join(clauses)
 
-        base_query = (
-            "SELECT id, course_id, db_type, student_id, student_name, created_at,"
-            " updated_at, content_html, content_json, source, meta"
-            " FROM messages WHERE " + where
-        )
-
         with self._conn(course_id) as conn:
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)")}
+            select_cols = [
+                "id",
+                "course_id",
+                "db_type",
+                "student_id",
+                "student_name",
+                "created_at",
+                "updated_at",
+            ]
+            if "content_html" in cols:
+                select_cols.append("content_html")
+            else:
+                # Legacy databases may miss this column; provide an empty placeholder
+                select_cols.append("'' AS content_html")
+            select_cols += ["content_json", "source", "meta"]
+            base_query = (
+                "SELECT " + ", ".join(select_cols) + " FROM messages WHERE " + where
+            )
+
             total = conn.execute(
                 f"SELECT COUNT(*) FROM messages WHERE {where}", params
             ).fetchone()[0]

--- a/tests/test_messages_store.py
+++ b/tests/test_messages_store.py
@@ -145,3 +145,39 @@ def test_ensure_schema_adds_updated_at(tmp_path):
     with sqlite3.connect(db_path) as conn:
         cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)")}
     assert "updated_at" in cols
+
+
+def test_ensure_schema_adds_content_html(tmp_path):
+    store = MessagesStore(tmp_path)
+    course_id = 13
+
+    # Create legacy database without the ``content_html`` column.
+    db_path = store._db_path(course_id)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE messages (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            course_id     INTEGER NOT NULL,
+            db_type       TEXT    NOT NULL,
+            student_id    TEXT    NOT NULL,
+            student_name  TEXT    NOT NULL,
+            created_at    INTEGER NOT NULL,
+            updated_at    INTEGER NOT NULL,
+            content_json  TEXT    NOT NULL,
+            source        TEXT    NOT NULL DEFAULT 'auto',
+            meta          TEXT
+        )
+        """,
+    )
+    conn.commit()
+    conn.close()
+
+    # Listing messages should upgrade the schema and return no rows.
+    rows = store.list_all(course_id)
+    assert rows["total"] == 0
+
+    # ``content_html`` column should now exist in the schema.
+    with sqlite3.connect(db_path) as conn:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)")}
+    assert "content_html" in cols


### PR DESCRIPTION
## Summary
- ensure legacy message databases get a content_html column to prevent query failures
- test schema migration for adding content_html to old databases
- handle missing content_html dynamically when listing messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac24bb02408324b543207bfcea45ed