### PR TITLE
Improve distance message editing and display

### DIFF
--- a/frontend/src/components/EditMessageDialog.tsx
+++ b/frontend/src/components/EditMessageDialog.tsx
@@ -37,23 +37,23 @@ export function EditMessageDialog({ open, onClose, message }: Props) {
     return () => clearInterval(interval)
   }, [open, editor, message])
 
-  function save(silent = false) {
+  async function save(silent = false) {
     if (!editor || !message) return
     const json = editor.getJSON()
     const html = editor.getHTML()
-    patch.mutate(
-      { id: message.id, data: { content_html: html, content_json: json, editor_version: 'tiptap-2' } },
-      {
-        onSuccess: () => {
-          setLastSaved(new Date())
-          if (!silent) {
-            toast.success('נשמר')
-            onClose()
-          }
-        },
-        onError: (e: any) => toast.error(e.message),
+    try {
+      await patch.mutateAsync({
+        id: message.id,
+        data: { content_html: html, content_json: json, editor_version: 'tiptap-2' },
+      })
+      setLastSaved(new Date())
+      if (!silent) {
+        toast.success('נשמר')
+        onClose()
       }
-    )
+    } catch (e: any) {
+      toast.error(e.message)
+    }
   }
 
   if (!open || !message) return null
@@ -62,6 +62,40 @@ export function EditMessageDialog({ open, onClose, message }: Props) {
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
       <div className="bg-white p-4 rounded w-full max-w-2xl">
         <h2 className="mb-2">עריכת הודעה ל{message.student_name}</h2>
+        {editor && (
+          <div className="flex flex-wrap gap-2 mb-2 border-b pb-2">
+            <button
+              className={editor.isActive('bold') ? 'font-bold bg-gray-200 px-2 py-1 rounded' : 'px-2 py-1 rounded'}
+              onClick={() => editor.chain().focus().toggleBold().run()}
+            >
+              B
+            </button>
+            <button
+              className={editor.isActive('italic') ? 'italic bg-gray-200 px-2 py-1 rounded' : 'italic px-2 py-1 rounded'}
+              onClick={() => editor.chain().focus().toggleItalic().run()}
+            >
+              I
+            </button>
+            <button
+              className={editor.isActive('underline') ? 'underline bg-gray-200 px-2 py-1 rounded' : 'underline px-2 py-1 rounded'}
+              onClick={() => editor.chain().focus().toggleUnderline().run()}
+            >
+              U
+            </button>
+            <button
+              className={editor.isActive('bulletList') ? 'bg-gray-200 px-2 py-1 rounded' : 'px-2 py-1 rounded'}
+              onClick={() => editor.chain().focus().toggleBulletList().run()}
+            >
+              •
+            </button>
+            <button
+              className={editor.isActive('orderedList') ? 'bg-gray-200 px-2 py-1 rounded' : 'px-2 py-1 rounded'}
+              onClick={() => editor.chain().focus().toggleOrderedList().run()}
+            >
+              1.
+            </button>
+          </div>
+        )}
         <div className="border rounded mb-2 p-2 max-h-96 overflow-y-auto">
           <EditorContent editor={editor} />
         </div>

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -37,7 +37,7 @@ export function FilterBar({ courseId, setCourseId, typeFilter, setTypeFilter, se
       <select className="border rounded p-1" value={typeFilter} onChange={e => setTypeFilter(e.target.value)}>
         <option value="all">הכל</option>
         {types.data?.types?.map((t: string) => (
-          <option key={t} value={t}>{t}</option>
+          <option key={t} value={t}>{t === 'distance' ? 'מרחק מציון היעד' : t}</option>
         ))}
       </select>
       <input className="border rounded p-1" placeholder="חיפוש" value={search} onChange={e => setSearch(e.target.value)} />

--- a/frontend/src/components/StudentCard.tsx
+++ b/frontend/src/components/StudentCard.tsx
@@ -19,9 +19,14 @@ export function StudentCard({ message, onEdit }: Props) {
           נוצר: {dayjs.unix(message.created_at).format('DD.MM.YYYY HH:mm')}<br/>
           עודכן: {dayjs.unix(message.updated_at).format('DD.MM.YYYY HH:mm')}
         </div>
+        {meta.target_score !== undefined && meta.total_score !== undefined && (
+          <div className="text-xs mb-2">
+            ציון מבחן: {meta.total_score} | ציון יעד: {meta.target_score}
+          </div>
+        )}
         {meta.gap !== undefined && (
           <div className="text-xs mb-2">
-            פער: <span className={meta.gap > 0 ? 'text-red-600' : 'text-green-600'}>{meta.gap}</span>
+            פער: <span className={meta.gap > 0 ? 'text-green-600' : meta.gap < 0 ? 'text-red-600' : ''}>{meta.gap}</span>
             {meta.gap_change !== undefined && meta.gap_change !== null && (
               <span className="ml-1">({meta.gap_change > 0 ? '+' : ''}{meta.gap_change})</span>
             )}


### PR DESCRIPTION
## Summary
- add basic formatting toolbar to edit-message dialog and close dialog after saving
- show test and target scores with corrected gap colors
- rename "distance" filter option to "מרחק מציון היעד"

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac287f46dc832487bd8f9337d81e24