### PR TITLE
Add exit buttons and fix bleach CSS warning

### DIFF
--- a/app/webapp.py
+++ b/app/webapp.py
@@ -303,6 +303,7 @@ async def patch_message(msg_id: int, body: PatchMessageBody):
 
     # Sanitize HTML
     import bleach
+    from bleach.css_sanitizer import CSSSanitizer
 
     allowed_tags = [
         "p",
@@ -328,6 +329,7 @@ async def patch_message(msg_id: int, body: PatchMessageBody):
         tags=allowed_tags,
         attributes=allowed_attrs,
         strip=True,
+        css_sanitizer=CSSSanitizer(),
     )
 
     try:

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -26,6 +26,9 @@ export default function LoginPage() {
 
   return (
     <div className="flex items-center justify-center h-screen bg-gray-100">
+      <button onClick={() => window.close()} className="fixed top-4 right-4 bg-gray-300 px-2 py-1 rounded">
+        יציאה
+      </button>
       <form onSubmit={submit} className="bg-white p-6 rounded shadow w-80 flex flex-col gap-2">
         <h1 className="text-xl mb-2 text-center">כניסה</h1>
         <input className="border p-2" placeholder="משתמש" value={username} onChange={e => setUsername(e.target.value)} />

--- a/frontend/src/pages/messages.tsx
+++ b/frontend/src/pages/messages.tsx
@@ -25,6 +25,9 @@ export default function MessagesPage() {
 
   return (
     <AppShell>
+      <button onClick={() => window.close()} className="fixed top-4 right-4 bg-gray-300 px-2 py-1 rounded">
+        יציאה
+      </button>
       <FilterBar
         courseId={courseId}
         setCourseId={setCourseId}


### PR DESCRIPTION
## Summary
- add exit button to login screen to close the app
- add exit button to messages page to close the app
- fix Bleach warning by enabling CSS sanitization

## Testing
- `pytest`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad785dfdf4832480a83e9ed2d4b929