### PR TITLE
fix: replace emoji-mart with react wrapper

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
       "name": "messages-ui",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
+        "@emoji-mart/react": "^1.1.1",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^6.0.0",
@@ -22,7 +23,6 @@
         "@tiptap/starter-kit": "^2.0.0-beta.220",
         "dayjs": "^1.11.9",
         "dompurify": "^3.0.6",
-        "emoji-mart": "^5.6.0",
         "lucide-react": "^0.292.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -368,6 +368,16 @@
       "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.2.1.tgz",
       "integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==",
       "license": "MIT"
+    },
+    "node_modules/@emoji-mart/react": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "emoji-mart": "^5.2",
+        "react": "^16.8 || ^17 || ^18"
+      }
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
@@ -3103,7 +3113,8 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
       "integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "@mui/icons-material": "^6.0.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "emoji-mart": "^5.6.0",
+    "@emoji-mart/react": "^1.1.1",
     "@emoji-mart/data": "^1.1.2"
   },
   "devDependencies": {

--- a/frontend/src/components/MessageEditorModal.test.tsx
+++ b/frontend/src/components/MessageEditorModal.test.tsx
@@ -14,8 +14,8 @@ vi.mock('react-hot-toast', () => ({
   default: { success: () => {}, error: () => {} },
 }))
 
-vi.mock('emoji-mart', () => ({
-  Picker: () => <div />,
+vi.mock('@emoji-mart/react', () => ({
+  default: () => <div />,
 }))
 
 test('save keeps modal open; save & close closes', async () => {

--- a/frontend/src/components/MessageEditorModal.tsx
+++ b/frontend/src/components/MessageEditorModal.tsx
@@ -10,7 +10,7 @@ import { usePatchMessage } from '../hooks/usePatchMessage'
 import toast from 'react-hot-toast'
 import { FormatBold, FormatItalic, FormatUnderlined, FormatColorText, EmojiEmotions, Undo, Redo } from '@mui/icons-material'
 import data from '@emoji-mart/data'
-import { Picker } from 'emoji-mart'
+import Picker from '@emoji-mart/react'
 
 const FontSize = Extension.create({
   name: 'fontSize',


### PR DESCRIPTION
## Summary
- replace emoji-mart with @emoji-mart/react to fix emoji picker runtime error
- update tests to mock @emoji-mart/react

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aed8656f18832495a06a1863c8318d