### PR TITLE
fix: correct PyInstaller paths

### DIFF
--- a/build/message_automation.spec
+++ b/build/message_automation.spec
@@ -5,10 +5,10 @@ block_cipher = None
 
 
 a = Analysis(
-    ['app/main.py'],
-    pathex=['.'],
+    ['../app/main.py'],
+    pathex=['..'],
     binaries=[],
-    datas=[('frontend/dist', 'frontend/dist'),('.env', '.')],
+    datas=[('../frontend/dist', 'frontend/dist'),('../.env', '.')],
     hiddenimports=[],
     hookspath=[],
     runtime_hooks=[],


### PR DESCRIPTION
## Summary
- fix paths in PyInstaller spec to reference project root

## Testing
- `pytest`
- `pnpm --dir frontend build`
- `scripts/make_installer.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aee50075a88324ace779d8e4b42d4f