### PR TITLE
fix: detect missing Python shared lib during packaging

### DIFF
--- a/scripts/make_installer.sh
+++ b/scripts/make_installer.sh
@@ -17,7 +17,13 @@ import os, sysconfig
 libdir = sysconfig.get_config_var('LIBDIR')
 ldlib = sysconfig.get_config_var('LDLIBRARY')
 path = os.path.join(libdir, ldlib) if libdir and ldlib else ''
-print(path if path and os.path.exists(path) else '')
+# Some Python builds expose only a static library (e.g. .a). PyInstaller requires
+# a shared library (.so, .dylib, .dll). Treat static libraries as missing.
+ext = os.path.splitext(ldlib)[1] if ldlib else ''
+if path and os.path.exists(path) and ext not in ('.a', '.lib'):
+    print(path)
+else:
+    print('')
 PYTHON
 )
 


### PR DESCRIPTION
## Summary
- improve make_installer.sh to ensure PyInstaller uses a shared Python library
- alert/attempt dev package installation if only static library is present

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeea91f4d08324a9b1a2e190059d2e