### PR TITLE
Bundle uvicorn and app modules in installer

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ import threading
 import webbrowser
 
 import uvicorn
+import app.webapp
 
 
 def _open_browser() -> None:
@@ -14,7 +15,7 @@ def _open_browser() -> None:
 if __name__ == "__main__":
     threading.Timer(1.0, _open_browser).start()
     uvicorn.run(
-        "app.webapp:app",
+        app.webapp.app,
         host="127.0.0.1",
         port=8765,
         reload=False,

--- a/build/message_automation.spec
+++ b/build/message_automation.spec
@@ -1,6 +1,8 @@
 # PyInstaller spec for message automation backend
 # This spec bundles the FastAPI server into a standalone executable.
 
+from PyInstaller.utils.hooks import collect_submodules
+
 block_cipher = None
 
 
@@ -9,7 +11,7 @@ a = Analysis(
     pathex=['..'],
     binaries=[],
     datas=[('../frontend/dist', 'frontend/dist'),('../.env', '.')],
-    hiddenimports=[],
+    hiddenimports=collect_submodules('uvicorn'),
     hookspath=[],
     runtime_hooks=[],
     excludes=[],


### PR DESCRIPTION
## Summary
- Import `app.webapp` at startup so PyInstaller bundles the application modules
- Include uvicorn in PyInstaller hidden imports

## Testing
- `KIDUM_USERNAME=dummy KIDUM_PASSWORD=dummy pytest`
- `scripts/make_installer.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aeebdb5bd08324bed38363affb1836