### PR TITLE
docs: expand and detail README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,95 @@
 # Message Automation
 
-Message Automation provides a FastAPI backend and a React + Vite frontend for managing course messages. The application is designed for local desktop use—no cloud deployment is required. When packaged, users install the executable and run everything on their own machine. Each user's data stays local; databases are created under the `data/` directory next to the executable by default. Set the `DATA_ROOT` environment variable to change this location.
+Message Automation is a desktop-focused utility for synchronising and editing course messages from the Kidum learning management system (LMS).  The project bundles a FastAPI backend, a React + Vite frontend and browser automation helpers.  Everything runs on the user's machine; databases and credentials never leave the local environment.
 
-Edit the provided `.env` and supply `KIDUM_USERNAME` and `KIDUM_PASSWORD` before running or packaging the app. Override `LMS_BASE_URL` and `LMS_API_BASE_URL` if you need to target a non-production environment. The packaged executable bundles this `.env` so end users do not configure anything.
+## Table of Contents
+- [Features](#features)
+- [Architecture](#architecture)
+- [Project Layout](#project-layout)
+- [Prerequisites](#prerequisites)
+- [Configuration](#configuration)
+- [Local Development](#local-development)
+  - [Backend](#backend)
+  - [Frontend](#frontend)
+  - [Browser Automation](#browser-automation)
+  - [Tests](#tests)
+- [Data Storage](#data-storage)
+- [Packaging and Distribution](#packaging-and-distribution)
+- [Troubleshooting](#troubleshooting)
+- [License](#license)
 
-## Backend
+## Features
 
-Install dependencies and run the server:
+- **Local-only operation** – the application logs in to the Kidum LMS and synchronises course data without sending anything to external servers.
+- **SQLite databases** – each course has its own message and distance databases under `data/courses/<teacher_id>/<course_id>/`.
+- **Web interface** – a React + Vite frontend served from the backend at `http://127.0.0.1:8765` for editing, patching and sanitising message content.
+- **Desktop login** – a PySide6 window manages the login flow and class selection while automation runs in a background thread.
+- **Optional distance analysis** – `/debug` routes expose helpers such as gap calculations for each student.
+- **Self-contained packaging** – PyInstaller and `makeself` produce a single installer for end users.
+
+## Architecture
+
+### Backend
+The FastAPI backend (`app/`) serves HTML routes, REST endpoints and static files.  On startup it also launches the default web browser pointing at the local interface.  Configuration values are read from environment variables via `dotenv`.
+
+### Frontend
+The frontend (`frontend/`) is built with React, Vite and Tailwind CSS.  It communicates with the backend through REST calls; the base URL is controlled by the `VITE_API_BASE` environment variable.
+
+### Automation
+Browser automation lives in `automation/` and relies on Playwright.  The `AutomationWorker` class performs login, class enumeration and selection in a background thread so the PySide6 UI remains responsive.
+
+### Data Layer
+Per-course SQLite databases store messages and distance information.  `app/services/paths.py` computes paths based on the `DATA_ROOT` configuration and optional environment names derived from `LMS_BASE_URL`.
+
+## Project Layout
+
+```
+app/           FastAPI application and service layer
+automation/    Playwright based browser automation
+frontend/      React + Vite user interface
+ui/            PySide6 desktop windows (login and class selection)
+build/         PyInstaller specification
+scripts/       Helper scripts (packaging, Playwright smoke test)
+tests/         Python unit and integration tests
+design/        Design assets and mockups
+logic/         Experimentation and prototypes
+```
+
+## Prerequisites
+
+- Python 3.11+ with pip
+- Node.js 18+ and [pnpm](https://pnpm.io) for the frontend
+- Playwright browsers (`playwright install`) when running live tests or packaging
+- `makeself` for bundling the installer (`apt-get install -y makeself` or `brew install makeself`)
+
+## Configuration
+
+Create a `.env` file next to the executable or at the repository root during development.  Populate the following variables:
+
+```
+KIDUM_USERNAME=<your username>
+KIDUM_PASSWORD=<your password>
+LMS_BASE_URL=https://kidum-me.com
+LMS_API_BASE_URL=https://lmsapi.kidum-me.com
+DATA_ROOT=data
+HEADLESS=true
+CORS_ORIGINS=http://127.0.0.1:8765,http://localhost:8765
+```
+
+Do **not** commit real credentials.  The `.env` file ships with the installer so end users do not need to configure anything.  Additional variables such as `APP_ENV` or `KIDUM_API_BASE_URL` can override environment-specific behaviour if required.
+
+## Local Development
+
+### Backend
 
 ```bash
 pip install -r requirements.txt
-python3 -m app.main
+python -m app.main
 ```
 
-The API listens on `http://127.0.0.1:8765`.
+The server listens on `http://127.0.0.1:8765` and opens the default browser.
 
-## Frontend
+### Frontend
 
 ```bash
 cd frontend
@@ -23,27 +97,57 @@ pnpm install
 pnpm dev
 ```
 
-The frontend uses the `VITE_API_BASE` environment variable to locate the backend (defaults to `http://127.0.0.1:8765`).
+`VITE_API_BASE` controls which backend URL the frontend talks to (defaults to `http://127.0.0.1:8765`).
 
-## Packaging
+### Browser Automation
 
-Build the frontend and generate a self-contained installer:
+Automation uses Playwright with optional GUI elements hidden by setting `HEADLESS=true`.  `scripts/smoke_playwright.py` provides a quick manual login check against the LMS.
 
-```bash
-pnpm --dir frontend build
-pip install pyinstaller
-sudo apt-get install -y makeself python3-dev # or: brew install makeself
-scripts/make_installer.sh
-```
+### Tests
 
-The script runs PyInstaller using `build/message_automation.spec` and then wraps the output in a self-extracting archive at `installer/message_automation.run`. Distribute that file to end users—they execute it, the bundled app extracts, and their browser opens on `127.0.0.1:8765`. Databases live under `data/` next to the executable. Make sure `.env` contains the required credentials before packaging so users have nothing to configure.
-
-## Testing
-
-Run the backend unit tests with:
+Backend and service tests run with `pytest`.  Set dummy credentials to satisfy login checks:
 
 ```bash
+export KIDUM_USERNAME=dummy
+export KIDUM_PASSWORD=dummy
 pytest
 ```
 
-The optional live browser test requires Playwright and real credentials. Provide `KIDUM_USERNAME` and `KIDUM_PASSWORD` and enable it with `RUN_LIVE_BROWSER_TEST=1` if you want to run it.
+Live browser tests require real credentials and Playwright support.  Enable them with `RUN_LIVE_BROWSER_TEST=1`.
+
+## Data Storage
+
+All data remains on the local machine.  `DATA_ROOT` defaults to `data/` and contains per-course directories:
+
+```
+<DATA_ROOT>/courses/<teacher_id>/<course_id>/
+    distance.db   # distance calculations
+    messages.db   # fetched and edited messages
+```
+
+Databases are created on demand with WAL journaling for safe concurrent access.
+
+## Packaging and Distribution
+
+Build a self-contained installer for distribution:
+
+```bash
+pnpm --dir frontend build
+pip install -r requirements.txt
+pip install pyinstaller
+sudo apt-get install -y makeself python3-dev  # or: brew install makeself
+scripts/make_installer.sh
+```
+
+The script runs PyInstaller using `build/message_automation.spec` and wraps the output with `makeself`.  The resulting `installer/message_automation.run` file extracts the application, installs Playwright dependencies if needed and launches the backend which in turn opens the browser for the user.
+
+## Troubleshooting
+
+- Missing Python headers during packaging → install the appropriate `python3-dev` package.
+- Ensure Playwright browsers are installed before running live tests or packaged builds.
+- Avoid committing the `dist/` and `installer/` folders; they are generated during packaging.
+
+## License
+
+This project does not currently include an explicit license.
+


### PR DESCRIPTION
## Summary
- elaborate project README with architecture breakdown, configuration reference and development workflow
- document data storage layout and packaging process

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3fe621b8483249b457a677408fcbd