### PR TITLE
Handle optional course ID and defer course fetch until login

### DIFF
--- a/app/webapp.py
+++ b/app/webapp.py
@@ -266,13 +266,18 @@ async def select_course(body: SelectCourseBody):
 
 @app.get("/messages")
 async def get_messages(
-    course_id: int,
+    course_id: int | None = None,
     type: str = "all",
     search: str | None = None,
     page: int = 1,
     limit: int = 30,
 ):
-    await _ensure_logged_in()
+    s = await _ensure_logged_in()
+    if course_id is None:
+        if hasattr(s, "get_selected_course_id") and s.get_selected_course_id():
+            course_id = s.get_selected_course_id()
+        else:
+            raise HTTPException(status_code=400, detail="course_id required")
     res = SYNC.list_messages(
         course_id,
         None if type == "all" else type,

--- a/frontend/src/hooks/useCourses.ts
+++ b/frontend/src/hooks/useCourses.ts
@@ -1,6 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import { api } from '../lib/api'
+import { useStatus } from './useStatus'
 
 export function useCourses() {
-  return useQuery({ queryKey: ['courses'], queryFn: api.courses })
+  const status = useStatus()
+  return useQuery({
+    queryKey: ['courses'],
+    queryFn: api.courses,
+    enabled: status.data?.logged_in,
+  })
 }

--- a/frontend/src/hooks/useMessages.ts
+++ b/frontend/src/hooks/useMessages.ts
@@ -5,12 +5,12 @@ export function useMessages(params: { course_id?: number; type?: string; search?
   return useInfiniteQuery({
     queryKey: ['messages', params],
     queryFn: ({ pageParam = 1 }) =>
-      api.messages({ course_id: params.course_id!, type: params.type, search: params.search, page: pageParam }),
+      api.messages({ course_id: params.course_id, type: params.type, search: params.search, page: pageParam }),
     getNextPageParam: lastPage => {
       const { page, limit, total } = lastPage
       return page * limit < total ? page + 1 : undefined
     },
-    enabled: !!params.course_id,
+    enabled: params.course_id != null,
   })
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -25,14 +25,15 @@ export const api = {
   selectCourse: (course_id: number) =>
     request('/select_course', { method: 'POST', body: JSON.stringify({ course_id }) }),
   messageTypes: (course_id: number) => request(`/message_types?course_id=${course_id}`),
-  messages: (params: { course_id: number; type?: string; search?: string; page?: number; limit?: number }) => {
+  messages: (params: { course_id?: number; type?: string; search?: string; page?: number; limit?: number }) => {
     const q = new URLSearchParams()
-    q.set('course_id', String(params.course_id))
+    if (params.course_id != null) q.set('course_id', String(params.course_id))
     if (params.type && params.type !== 'all') q.set('type', params.type)
     if (params.search) q.set('search', params.search)
     if (params.page) q.set('page', String(params.page))
     if (params.limit) q.set('limit', String(params.limit))
-    return request(`/messages?${q.toString()}`)
+    const qs = q.toString()
+    return request(`/messages${qs ? `?${qs}` : ''}`)
   },
   patchMessage: (id: number, data: any) =>
     request(`/messages/${id}`, {


### PR DESCRIPTION
## Summary
- Allow `/messages` to use the selected course when `course_id` is not provided
- Skip sending `course_id=undefined` from the frontend API helper
- Treat `course_id` as optional in `useMessages` hook
- Fetch courses only after login to avoid unauthorized requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b40f00b5f0832484cb6e281c34ba8d