### PR TITLE
Add Dockerfile for local desktop container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Ignore Git metadata and local files
+.git
+.gitignore
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+
+# Build artifacts
+/dist/
+/installer/
+/build/
+/data/
+
+# Frontend development files
+/frontend/node_modules/
+/frontend/dist/
+/tests/
+/design/
+/logic/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+# Build frontend assets
+FROM node:18 AS frontend-build
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ .
+RUN npm run build
+
+# Final image
+FROM python:3.11-slim
+WORKDIR /app
+
+# Avoid buffering and configure headless defaults
+ENV PYTHONUNBUFFERED=1 \
+    HEADLESS=true \
+    KIDUM_USERNAME=dummy \
+    KIDUM_PASSWORD=dummy
+
+# Install Python dependencies and Playwright browsers
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt && \
+    playwright install --with-deps chromium
+
+# Copy application code and built frontend
+COPY app ./app
+COPY automation ./automation
+COPY ui ./ui
+COPY --from=frontend-build /frontend/dist ./frontend/dist
+
+EXPOSE 8765
+CMD ["python", "-m", "app.main"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Message Automation is a desktop-focused utility for synchronising and editing co
   - [Tests](#tests)
 - [Data Storage](#data-storage)
 - [Packaging and Distribution](#packaging-and-distribution)
+- [Docker](#docker)
 - [Troubleshooting](#troubleshooting)
 - [License](#license)
 
@@ -140,6 +141,20 @@ scripts/make_installer.sh
 ```
 
 The script runs PyInstaller using `build/message_automation.spec` and wraps the output with `makeself`.  The resulting `installer/message_automation.run` file extracts the application, installs Playwright dependencies if needed and launches the backend which in turn opens the browser for the user.
+
+## Docker
+
+A Docker image can run the application on Windows, macOS or Linux PCs without a full Python/Node.js setup. Build the image and start the container locally:
+
+```bash
+docker build -t message-automation .
+docker run --rm -p 8765:8765 \
+  -e KIDUM_USERNAME=<your username> \
+  -e KIDUM_PASSWORD=<your password> \
+  message-automation
+```
+
+Then open `http://127.0.0.1:8765` in your browser. The container runs headless and keeps all data inside its filesystem, so mount a volume to persist databases if needed.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile to build frontend and run backend
- ignore development artifacts with .dockerignore
- document building and running image in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b43ef61b3c83249b587e08d4346e11