### PR TITLE
Fix login status detection without display name

### DIFF
--- a/app/webapp.py
+++ b/app/webapp.py
@@ -217,7 +217,7 @@ async def courses(names_only: bool = False):
 @app.get("/status")
 async def status():
     s = _get_session(False)
-    logged_in = bool(s and s.get_logged_in_display_name())
+    logged_in = bool(s and s.get_teacher_id())
     return {
         "ok": True,
         "logged_in": logged_in,

--- a/automation/api_client.py
+++ b/automation/api_client.py
@@ -44,8 +44,13 @@ async def login(username: str, password: str, client: Optional[httpx.AsyncClient
         data = resp.json()
 
         token = data.get("token")
-        teacher_id = data.get("data", {}).get("id")
-        display_name = data.get("data", {}).get("name")
+        user_data = data.get("data", {})
+        teacher_id = user_data.get("id")
+        display_name = (
+            user_data.get("name")
+            or user_data.get("full_name")
+            or (f"{user_data.get('first_name', '')} {user_data.get('last_name', '')}".strip() or None)
+        )
 
         if not token or teacher_id is None:
             raise ValueError("token or teacher_id missing in response")

--- a/tests/test_status_session.py
+++ b/tests/test_status_session.py
@@ -29,3 +29,37 @@ def test_status_reports_logged_out_for_partial_session():
     client.post('/logout')
     assert dummy.closed is True
     assert webapp._session is None
+
+
+class NamelessSession:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+    def get_logged_in_display_name(self):
+        return None
+
+    def get_teacher_id(self):
+        return 1
+
+    def get_selected_course_id(self):
+        return None
+
+
+def test_status_logged_in_without_display_name():
+    dummy = NamelessSession()
+    webapp._session = dummy
+    client = TestClient(webapp.app)
+    status = client.get('/status').json()
+    assert status == {
+        'ok': True,
+        'logged_in': True,
+        'display_name': None,
+        'teacher_id': 1,
+        'selected_id': None,
+    }
+    client.post('/logout')
+    assert dummy.closed is True
+    assert webapp._session is None


### PR DESCRIPTION
## Summary
- derive display name from additional API fields
- determine login status based on teacher ID instead of display name
- add regression test for sessions lacking display name

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7f2fcea488324a1081c3654d08bb9