### PR TITLE
Use psycopg driver for Postgres connections

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -21,7 +21,7 @@ class _Config:
     )
     database_url: str = os.getenv(
         "DATABASE_URL",
-        "postgresql://localhost:5432/message_automation",
+        "postgresql+psycopg://localhost:5432/message_automation",
     )
     headless: bool = os.getenv("HEADLESS", "true").lower() in ("1", "true", "yes")
     cors_origins: List[str] = field(

--- a/app/db/postgres_setup.py
+++ b/app/db/postgres_setup.py
@@ -27,7 +27,16 @@ from sqlalchemy.engine import Engine
 
 
 def get_engine(url: str) -> Engine:
-    """Return a SQLAlchemy engine for ``url``."""
+    """Return a SQLAlchemy engine for ``url``.
+
+    SQLAlchemy defaults to the legacy ``psycopg2`` driver when the scheme is
+    ``postgresql://``.  The project depends on the newer ``psycopg`` driver, so
+    upgrade the URL if no explicit driver is provided.
+    """
+
+    if url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+psycopg://", 1)
+
     return create_engine(url, pool_pre_ping=True)
 
 


### PR DESCRIPTION
## Summary
- default `DATABASE_URL` now specifies the psycopg driver
- database engine helper upgrades plain `postgresql://` URLs to use psycopg

## Testing
- `KIDUM_USERNAME=dummy KIDUM_PASSWORD=dummy pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b81f352998832487ae26ce772d2c1e