### PR TITLE
docs: document database url credentials

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,4 @@ KIDUM_USERNAME=
 KIDUM_PASSWORD=
 LMS_BASE_URL=https://kidum-me.com
 LMS_API_BASE_URL=https://lmsapi.kidum-me.com
+DATABASE_URL=postgresql+psycopg://user:pass@localhost:5432/message_automation

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ KIDUM_USERNAME=<your username>
 KIDUM_PASSWORD=<your password>
 LMS_BASE_URL=https://kidum-me.com
 LMS_API_BASE_URL=https://lmsapi.kidum-me.com
+DATABASE_URL=postgresql+psycopg://user:pass@localhost:5432/message_automation
 DATA_ROOT=data
 CORS_ORIGINS=http://127.0.0.1:8765,http://localhost:8765
 ```
@@ -116,9 +117,12 @@ teacher_<teacher_id>.messages   -- fetched and edited messages
 teacher_<teacher_id>.score_gap  -- distance/score gap calculations
 ```
 
-Set the connection string via the `DATABASE_URL` environment variable.  The
-per-teacher schema layout allows additional tables to be added in the future
-without affecting other users.
+Set the connection string via the `DATABASE_URL` environment variable (for
+example `postgresql+psycopg://user:pass@localhost:5432/message_automation`).
+Include credentials in the URL; missing passwords will result in a
+`fe_sendauth: no password supplied` error from the driver.  The per-teacher
+schema layout allows additional tables to be added in the future without
+affecting other users.
 
 ## Packaging and Distribution
 


### PR DESCRIPTION
## Summary
- add placeholder `DATABASE_URL` to default `.env`
- clarify in README that the connection string must include credentials

## Testing
- `KIDUM_USERNAME=test KIDUM_PASSWORD=test pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b8256d98008324a5d6bf21c9a1a3c0