### PR TITLE
Handle placeholder database credentials

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -6,6 +6,25 @@ from typing import List
 from urllib.parse import urlparse
 from dotenv import load_dotenv
 
+
+def _get_database_url() -> str:
+    """Return a sanitized database URL.
+
+    The default ``.env`` file includes placeholder credentials
+    (``user:pass``) which, if used verbatim, trigger authentication
+    failures when connecting to Postgres.  Detect this case and fall
+    back to a URL without credentials or host so that local
+    environments relying on peer authentication over Unix sockets can
+    function without embedding secrets.
+    """
+
+    raw = os.getenv("DATABASE_URL")
+    if raw:
+        parsed = urlparse(raw)
+        if parsed.username == "user" and parsed.password == "pass":
+            raw = None
+    return raw or "postgresql+psycopg:///message_automation"
+
 # Ensure variables from a local .env file are available before constructing the config
 load_dotenv()
 
@@ -19,10 +38,7 @@ class _Config:
         os.getenv("LMS_API_BASE_URL")
         or os.getenv("KIDUM_API_BASE_URL", "https://lmsapi.kidum-me.com")
     )
-    database_url: str = os.getenv(
-        "DATABASE_URL",
-        "postgresql+psycopg://localhost:5432/message_automation",
-    )
+    database_url: str = field(default_factory=_get_database_url)
     headless: bool = os.getenv("HEADLESS", "true").lower() in ("1", "true", "yes")
     cors_origins: List[str] = field(
         default_factory=lambda: os.getenv(

--- a/tests/test_config_db_url.py
+++ b/tests/test_config_db_url.py
@@ -1,0 +1,17 @@
+import importlib
+import os
+
+import app.config as config
+
+
+def test_placeholder_database_url(monkeypatch):
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+psycopg://user:pass@localhost:5432/whatever",
+    )
+    importlib.reload(config)
+    assert (
+        config.CONFIG.database_url
+        == "postgresql+psycopg:///message_automation"
+    )
+    monkeypatch.delenv("DATABASE_URL")


### PR DESCRIPTION
## Summary
- Sanitize DATABASE_URL in config to ignore placeholder `user:pass` values
- Default missing credentials to Unix-socket connection for peer auth
- Add regression test for placeholder database URL handling

## Testing
- `KIDUM_USERNAME=foo KIDUM_PASSWORD=bar pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b826b7e8b4832494529b5326f3c8e9