### PR TITLE
Ensure teacher schema creation is committed

### DIFF
--- a/app/db/postgres_setup.py
+++ b/app/db/postgres_setup.py
@@ -49,8 +49,11 @@ def ensure_teacher_schema(engine: Engine, teacher_id: str) -> None:
     """
 
     schema = f"teacher_{teacher_id}"
-    conn = engine.connect()
-    try:
+    # Use a transaction so that the schema and table creation is committed.
+    # Without an explicit commit, ``CREATE`` statements executed on a plain
+    # connection would be rolled back when the connection closes, leading to
+    # missing tables at runtime.
+    with engine.begin() as conn:
         conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
         metadata = MetaData(schema=schema)
 
@@ -94,7 +97,3 @@ def ensure_teacher_schema(engine: Engine, teacher_id: str) -> None:
         )
 
         metadata.create_all(conn)
-    finally:
-        close = getattr(conn, "close", None)
-        if callable(close):
-            close()

--- a/tests/test_postgres_setup.py
+++ b/tests/test_postgres_setup.py
@@ -1,12 +1,21 @@
+from contextlib import contextmanager
+
 from app.db.postgres_setup import ensure_teacher_schema
 from sqlalchemy import create_mock_engine
 
 
 def test_ensure_teacher_schema_emits_expected_sql():
     statements = []
-    engine = create_mock_engine(
+    mock_conn = create_mock_engine(
         "postgresql://", executor=lambda sql, *m, **p: statements.append(str(sql))
     )
+
+    class DummyEngine:
+        @contextmanager
+        def begin(self):
+            yield mock_conn
+
+    engine = DummyEngine()
     ensure_teacher_schema(engine, "t1")
     assert any("CREATE SCHEMA IF NOT EXISTS \"teacher_t1\"" in s for s in statements)
     assert any("teacher_t1.messages" in s for s in statements)


### PR DESCRIPTION
## Summary
- create per-teacher schema and tables inside a transaction so DDL is committed
- adapt schema creation test to work with transactional engine

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b82a0fc39c832484c20e4cde294380