### PR TITLE
Fix schema quoting for upsert message

### DIFF
--- a/app/services/messages_store.py
+++ b/app/services/messages_store.py
@@ -54,12 +54,12 @@ class MessagesStore:
                 student_name=excluded.student_name,
                 updated_at=excluded.updated_at,
                 meta=excluded.meta,
-                content_html=CASE WHEN {self.schema}.messages.source='auto'
-                                  THEN excluded.content_html ELSE {self.schema}.messages.content_html END,
-                content_json=CASE WHEN {self.schema}.messages.source='auto'
-                                   THEN excluded.content_json ELSE {self.schema}.messages.content_json END,
-                source=CASE WHEN {self.schema}.messages.source='auto'
-                            THEN excluded.source ELSE {self.schema}.messages.source END
+                content_html=CASE WHEN "{self.schema}".messages.source='auto'
+                                  THEN excluded.content_html ELSE "{self.schema}".messages.content_html END,
+                content_json=CASE WHEN "{self.schema}".messages.source='auto'
+                                   THEN excluded.content_json ELSE "{self.schema}".messages.content_json END,
+                source=CASE WHEN "{self.schema}".messages.source='auto'
+                            THEN excluded.source ELSE "{self.schema}".messages.source END
             """
         )
         with self.engine.begin() as conn:


### PR DESCRIPTION
## Summary
- fix schema quoting in upsert query for MessagesStore to handle UUID-based schema names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b82efbdc048324862273e97ebf1d72