### PR TITLE
Handle nested distance data structure

### DIFF
--- a/automation/api_client.py
+++ b/automation/api_client.py
@@ -127,4 +127,19 @@ class KidumApiSession:
         payload = r.json()
         if not payload.get("status"):
             raise RuntimeError(f"Distance API error: {payload}")
-        return payload.get("data", [])
+        data = payload.get("data", [])
+        # The API historically returned a list directly under the ``data`` key,
+        # but newer versions wrap the data inside an object which may contain
+        # separate lists for new and updated rows (e.g. ``{"new": [...], "updated": [...]}``).
+        # Gather all list values so both newly inserted and modified records are
+        # processed.  This prevents silent failures when one of the lists is
+        # empty or ignored by older client logic.
+        if isinstance(data, dict):
+            combined: List[Dict[str, Any]] = []
+            for value in data.values():
+                if isinstance(value, list):
+                    combined.extend(value)
+            data = combined
+        elif not isinstance(data, list):
+            data = []
+        return data

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -43,3 +43,51 @@ async def test_session_helpers():
         assert courses == courses_payload["data"]
         dist = await sess.api_get_distance_details(1)
         assert dist == dist_payload["data"]
+
+
+@pytest.mark.asyncio
+async def test_distance_details_nested_structure():
+    """The distance details endpoint may wrap the list in a nested object."""
+    login_payload = {"status": True, "token": "tok", "data": {"id": 9, "name": "T"}}
+    nested_payload = {"status": True, "data": {"rows": [{"student_id": "s1"}]}}
+
+    async def handler(request):
+        if request.url.path == "/api/client-login":
+            return httpx.Response(200, json=login_payload)
+        if request.url.path == "/api/get-distance-details":
+            return httpx.Response(200, json=nested_payload)
+        raise AssertionError(f"unexpected path: {request.url.path}")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        sess = api_client.KidumApiSession(client)
+        assert await sess.login("u", "p")
+        dist = await sess.api_get_distance_details(1)
+    assert dist == nested_payload["data"]["rows"]
+
+
+@pytest.mark.asyncio
+async def test_distance_details_merges_multiple_lists():
+    """Multiple list values should be combined (new and updated entries)."""
+    login_payload = {"status": True, "token": "tok", "data": {"id": 9, "name": "T"}}
+    multi_payload = {
+        "status": True,
+        "data": {
+            "new": [{"student_id": "s0"}],
+            "updated": [{"student_id": "s1"}],
+        },
+    }
+
+    async def handler(request):
+        if request.url.path == "/api/client-login":
+            return httpx.Response(200, json=login_payload)
+        if request.url.path == "/api/get-distance-details":
+            return httpx.Response(200, json=multi_payload)
+        raise AssertionError(f"unexpected path: {request.url.path}")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        sess = api_client.KidumApiSession(client)
+        assert await sess.login("u", "p")
+        dist = await sess.api_get_distance_details(1)
+    assert dist == multi_payload["data"]["new"] + multi_payload["data"]["updated"]


### PR DESCRIPTION
## Summary
- merge all list values from distance details response so both new and updated records are detected
- extend API client tests to ensure multiple list sections are combined

## Testing
- `KIDUM_USERNAME=dummy KIDUM_PASSWORD=dummy pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8330a96988324b341331311ebe696