### PR TITLE
fix: handle nested distance details data

### DIFF
--- a/automation/api_client.py
+++ b/automation/api_client.py
@@ -135,11 +135,23 @@ class KidumApiSession:
         # processed.  This prevents silent failures when one of the lists is
         # empty or ignored by older client logic.
         if isinstance(data, dict):
-            combined: List[Dict[str, Any]] = []
-            for value in data.values():
-                if isinstance(value, list):
-                    combined.extend(value)
-            data = combined
+            # The API keeps evolving and may nest the relevant row lists under
+            # multiple layers (e.g. ``{"new": {"rows": [...]}}``).  Traverse
+            # the structure and gather every list encountered so no entries are
+            # missed regardless of the exact shape returned by the server.
+            def _gather(obj: Any) -> List[Dict[str, Any]]:
+                collected: List[Dict[str, Any]] = []
+                if isinstance(obj, list):
+                    for item in obj:
+                        if isinstance(item, dict):
+                            collected.append(item)
+                    return collected
+                if isinstance(obj, dict):
+                    for val in obj.values():
+                        collected.extend(_gather(val))
+                return collected
+
+            data = _gather(data)
         elif not isinstance(data, list):
             data = []
         return data

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -91,3 +91,34 @@ async def test_distance_details_merges_multiple_lists():
         assert await sess.login("u", "p")
         dist = await sess.api_get_distance_details(1)
     assert dist == multi_payload["data"]["new"] + multi_payload["data"]["updated"]
+
+
+@pytest.mark.asyncio
+async def test_distance_details_handles_nested_lists():
+    """Lists nested inside objects (e.g. ``{"new": {"rows": [...]}}``) are flattened."""
+    login_payload = {"status": True, "token": "tok", "data": {"id": 9, "name": "T"}}
+    nested_lists_payload = {
+        "status": True,
+        "data": {
+            "new": {"rows": [{"student_id": "s0"}]},
+            "updated": {"rows": [{"student_id": "s1"}]},
+        },
+    }
+
+    async def handler(request):
+        if request.url.path == "/api/client-login":
+            return httpx.Response(200, json=login_payload)
+        if request.url.path == "/api/get-distance-details":
+            return httpx.Response(200, json=nested_lists_payload)
+        raise AssertionError(f"unexpected path: {request.url.path}")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        sess = api_client.KidumApiSession(client)
+        assert await sess.login("u", "p")
+        dist = await sess.api_get_distance_details(1)
+    expected = (
+        nested_lists_payload["data"]["new"]["rows"]
+        + nested_lists_payload["data"]["updated"]["rows"]
+    )
+    assert dist == expected


### PR DESCRIPTION
## Summary
- flatten arbitrarily nested lists from distance details API to ensure message sync processes all rows
- test api client against nested list structures

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b834ddac708324a0d00b321f15d96a