### PR TITLE
Ensure messages created for unseen students

### DIFF
--- a/app/services/distance_syncer.py
+++ b/app/services/distance_syncer.py
@@ -198,5 +198,47 @@ class DistanceSyncer:
             "target_score": target_score,
             "total_score": total_score,
             "gap": gap,
-            "gap_change": gap_change,
-        }
+                "gap_change": gap_change,
+            }
+
+    # ------------------------------------------------------------------
+    def list_students(self, course_id: int) -> List[Dict]:
+        """Return all score-gap rows for ``course_id``."""
+
+        with self.engine.begin() as conn:
+            rows = conn.execute(
+                text(
+                    f"""
+                    SELECT student_id, student_name, last_exam_date, exam_name,
+                           target_score, total_score, gap, gap_change
+                      FROM "{self.schema}".score_gap
+                     WHERE course_id=:course_id
+                    """
+                ),
+                {"course_id": course_id},
+            ).fetchall()
+        data: List[Dict] = []
+        for r in rows:
+            (
+                sid,
+                sname,
+                last_exam_date,
+                exam_name,
+                target_score,
+                total_score,
+                gap,
+                gap_change,
+            ) = r
+            data.append(
+                {
+                    "student_id": sid,
+                    "student_name": sname,
+                    "last_exam_date": last_exam_date,
+                    "exam_name": exam_name,
+                    "target_score": target_score,
+                    "total_score": total_score,
+                    "gap": gap,
+                    "gap_change": gap_change,
+                }
+            )
+        return data

--- a/app/services/messages_store.py
+++ b/app/services/messages_store.py
@@ -81,6 +81,20 @@ class MessagesStore:
             )
 
     # ------------------------------------------------------------------
+    def student_ids_with_messages(self, course_id: int, db_type: str = "distance"):
+        """Return the set of student IDs that already have messages."""
+
+        with self.engine.begin() as conn:
+            rows = conn.execute(
+                text(
+                    f'SELECT student_id FROM "{self.schema}".messages '
+                    'WHERE course_id=:course_id AND db_type=:db_type'
+                ),
+                {"course_id": course_id, "db_type": db_type},
+            ).fetchall()
+        return {r[0] for r in rows}
+
+    # ------------------------------------------------------------------
     def list_all(
         self,
         course_id: int,

--- a/app/services/orchestrator.py
+++ b/app/services/orchestrator.py
@@ -50,7 +50,38 @@ class SyncOrchestrator:
                 meta=meta,
                 created_at=now,
             )
-        return {"distance": dist, "messages_emitted": len(dist["changes"])}
+        existing_ids = self.messages.student_ids_with_messages(course_id)
+        missing = 0
+        for row in self.distance.list_students(course_id):
+            sid = row["student_id"]
+            if sid in existing_ids:
+                continue
+            text = build_student_message(
+                {
+                    "kind": "inserted",
+                    "student_name": row.get("student_name", ""),
+                    "exam_name": row.get("exam_name"),
+                    "old_gap": None,
+                    "new_gap": row.get("gap"),
+                }
+            )
+            self.messages.upsert_message(
+                course_id=course_id,
+                db_type="distance",
+                student_id=sid,
+                student_name=row.get("student_name", ""),
+                content_html=f"<p>{text}</p>",
+                content_json={
+                    "type": "doc",
+                    "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": text}]}
+                    ],
+                },
+                meta=row,
+                created_at=now,
+            )
+            missing += 1
+        return {"distance": dist, "messages_emitted": len(dist["changes"]) + missing}
 
     def list_messages(
         self,

--- a/tests/test_orchestrator_sync_all.py
+++ b/tests/test_orchestrator_sync_all.py
@@ -1,0 +1,78 @@
+import asyncio
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_mock_engine
+
+from app.services.orchestrator import SyncOrchestrator
+
+
+class DummySession:
+    pass
+
+
+class DummyDistanceSyncer:
+    schema = "teacher_t1"
+
+    async def sync_and_collect(self, session, course_id):
+        # No changes reported from the distance sync
+        return {"inserted": 0, "updated": 0, "changes": []}
+
+    def get_student(self, course_id, student_id):
+        return {
+            "student_name": "Alice",
+            "exam_name": "Exam",
+            "last_exam_date": None,
+            "target_score": None,
+            "total_score": None,
+            "gap": 5,
+            "gap_change": None,
+        }
+
+    def list_students(self, course_id):
+        return [
+            {
+                "student_id": "s1",
+                "student_name": "Alice",
+                "exam_name": "Exam",
+                "last_exam_date": None,
+                "target_score": None,
+                "total_score": None,
+                "gap": 5,
+                "gap_change": None,
+            }
+        ]
+
+
+class DummyMessagesStore:
+    def __init__(self):
+        self.calls = []
+
+    def upsert_message(self, **kwargs):
+        self.calls.append(kwargs)
+
+    def student_ids_with_messages(self, course_id, db_type="distance"):
+        return set()
+
+
+def make_engine():
+    mock = create_mock_engine("postgresql://", executor=lambda *a, **k: None)
+
+    class Engine:
+        @contextmanager
+        def begin(self):
+            yield mock
+
+    return Engine()
+
+
+def test_sync_all_adds_message_for_missing_student():
+    engine = make_engine()
+    orch = SyncOrchestrator("t1", engine=engine)
+    orch.distance = DummyDistanceSyncer()
+    orch.messages = DummyMessagesStore()
+
+    asyncio.run(orch.sync_all(DummySession(), course_id=1))
+
+    assert len(orch.messages.calls) == 1
+    assert orch.messages.calls[0]["student_id"] == "s1"


### PR DESCRIPTION
## Summary
- create helper to list message student IDs and distance rows
- auto-generate message rows for students lacking entries
- test that sync populates message for previously unseen student

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b83a423f34832495fa6cd10fccc5ff