### PR TITLE
Fix refresh button to trigger course sync

### DIFF
--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -53,8 +53,17 @@ export function FilterBar({ courseId, setCourseId, typeFilter, setTypeFilter, se
       <button
         className="px-3 py-1 bg-primary text-white rounded hover:brightness-110 transition focus-visible:outline-primary focus-visible:outline-2"
         onClick={() => {
-          onRefresh()
-          toast.success('רשימה עודכנה')
+          if (courseId == null) {
+            toast.error('בחר קורס')
+            return
+          }
+          api
+            .selectCourse(courseId)
+            .then(() => {
+              onRefresh()
+              toast.success('רשימה עודכנה')
+            })
+            .catch(err => toast.error(err.message))
         }}
       >
         רענון


### PR DESCRIPTION
## Summary
- Ensure refresh button re-selects current course before updating messages
- Warn user if refresh pressed without selecting a course

## Testing
- `pnpm test` *(fails: Test timed out in 5000ms)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b840495fb48324b455cd82ff99bb67