### PR TITLE
Refresh triggers course selection

### DIFF
--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -52,7 +52,16 @@ export function FilterBar({ courseId, setCourseId, typeFilter, setTypeFilter, se
       />
       <button
         className="px-3 py-1 bg-primary text-white rounded hover:brightness-110 transition focus-visible:outline-primary focus-visible:outline-2"
-        onClick={onRefresh}
+        onClick={() => {
+          if (courseId == null) {
+            toast.error('בחר קורס')
+            return
+          }
+          api
+            .selectCourse(courseId)
+            .then(() => onRefresh())
+            .catch(err => toast.error(err.message))
+        }}
       >
         רענון
       </button>

--- a/frontend/src/pages/messages.tsx
+++ b/frontend/src/pages/messages.tsx
@@ -46,17 +46,8 @@ export default function MessagesPage() {
         search={search}
         setSearch={setSearch}
         onRefresh={() => {
-          if (courseId == null) {
-            toast.error('בחר קורס')
-            return
-          }
-          api
-            .selectCourse(courseId)
-            .then(() => {
-              messages.refetch()
-              toast.success('רשימה עודכנה')
-            })
-            .catch(err => toast.error(err.message))
+          messages.refetch()
+          toast.success('רשימה עודכנה')
         }}
       />
       <div className="p-4 grid gap-6" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(250px,1fr))' }}>


### PR DESCRIPTION
## Summary
- Ensure refresh button re-selects the current course before reloading messages
- Simplify messages page refresh handler

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8440beda083248f2a52b55c71bae5